### PR TITLE
Improve NetworkManager compatibility

### DIFF
--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -3123,7 +3123,14 @@ static int cfg80211_rtw_disconnect(struct wiphy *wiphy, struct net_device *ndev,
 
 		DBG_871X("%s...call rtw_indicate_disconnect\n", __FUNCTION__);
 
+		// Temporarily enable disconnect indication here
+		// in order to properly notify cfg80211 about actual disconnection
+		// and clean up old connection settings.
+		// Without this fix NetworkManager fails to connect to a new access point
+		// after disconnection from another.
+		padapter->mlmepriv.not_indic_disco = _FALSE;
 		rtw_indicate_disconnect(padapter);
+		padapter->mlmepriv.not_indic_disco = _TRUE;
 
 		rtw_free_assoc_resources(padapter, 1);
 		rtw_pwr_wakeup(padapter);

--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -2133,6 +2133,20 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 		pbuddy_adapter = padapter->pbuddy_adapter;
 		pbuddy_mlmepriv = &(pbuddy_adapter->mlmepriv);
 	}
+
+	// check if buddy adapter is configured as client,
+	// if so, deny scan immediately (rtl8723bu can't act as two clients)
+	DBG_871X("scan request for %s\n", ndev->name);
+	DBG_871X("this wlan state %08x\n", pmlmepriv->fw_state);
+	if (pbuddy_mlmepriv) {
+		DBG_871X("buddy wlan state %08x\n", pbuddy_mlmepriv->fw_state);
+	}
+
+	if (pbuddy_mlmepriv && check_fwstate(pbuddy_mlmepriv, WIFI_ASOC_STATE) == _TRUE) {
+		DBG_871X("scan on %s is cancelled, another interface is the client here\n", ndev->name);
+		ret = -EBUSY;
+		goto exit;
+	}
 #endif //CONFIG_CONCURRENT_MODE
 
 	SPIN_LOCK_BH(pwdev_priv->scan_req_lock, &irqL);


### PR DESCRIPTION
[os_dep: fix disconnect indication on actual disconnect](https://github.com/wirenboard/rtl8723bu/commit/c688e689f26012d7a476caddde48f991fbd31b21)

This patch enables disconnect indication on actual disconnect
in order to properly notify cfg80211 about actual disconnection
and clean up old connection settings.

Without this patch NetworkManager fails to connect to a new access point
after disconnection from another.

(IDK why to disable disconnect indication in the first place)

[os_dep: disallow scan on buddy interface if configured as client](https://github.com/wirenboard/rtl8723bu/commit/dcf85b2138fd6953ac5e3cfa2d26901b01dd236a)

rtl8723bu in concurrent mode can't act as two clients properly,
but NetworkManager still tries to scan on both available interfaces.

This breaks connection configured as client, network becomes
unavailable.

This patch prevent scan to start on specific interface if its
buddy is configured as client.