### PR TITLE
Improve NetworkManager compatibility even more

### DIFF
--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -2931,6 +2931,14 @@ static int cfg80211_rtw_connect(struct wiphy *wiphy, struct net_device *ndev,
 		ret = -EINVAL;
 		goto exit;
 	}
+
+	if (check_buddy_fwstate(padapter, WIFI_STATION_STATE) == _TRUE &&
+			check_buddy_fwstate(padapter, WIFI_ASOC_STATE) == _TRUE) {
+		DBG_871X("%s, but buddy_intf is connected to AP\n", __FUNCTION__);
+		ret = -EINVAL;
+		goto exit;
+	}
+
 	if (check_buddy_fwstate(padapter, _FW_UNDER_SURVEY) == _TRUE) {
 		rtw_scan_abort(padapter->pbuddy_adapter);
 	}
@@ -3965,6 +3973,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
 	int ret = 0;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
 
+#ifdef CONFIG_CONCURRENT_MODE
+	if (check_buddy_fwstate(adapter, WIFI_AP_STATE) == _TRUE &&
+			check_buddy_fwstate(adapter, WIFI_ASOC_STATE) == _TRUE) {
+		DBG_871X("%s, but buddy_intf is configured as AP\n", __FUNCTION__);
+		ret = -EINVAL;
+		goto exit;
+	}
+#endif
+
 	DBG_871X(FUNC_NDEV_FMT" hidden_ssid:%d, auth_type:%d\n", FUNC_NDEV_ARG(ndev),
 		settings->hidden_ssid, settings->auth_type);
 
@@ -3983,6 +4000,7 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
 		pbss_network_ext->Ssid.SsidLength = settings->ssid_len;
 	}
 
+exit:
 	return ret;
 }
 

--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -2142,7 +2142,8 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 		DBG_871X("buddy wlan state %08x\n", pbuddy_mlmepriv->fw_state);
 	}
 
-	if (pbuddy_mlmepriv && check_fwstate(pbuddy_mlmepriv, WIFI_ASOC_STATE) == _TRUE) {
+	if (pbuddy_mlmepriv && check_fwstate(pbuddy_mlmepriv, WIFI_ASOC_STATE) == _TRUE &&
+			check_fwstate(pbuddy_mlmepriv, WIFI_STATION_STATE) == _TRUE) {
 		DBG_871X("scan on %s is cancelled, another interface is the client here\n", ndev->name);
 		ret = -EBUSY;
 		goto exit;

--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -2143,7 +2143,8 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 	}
 
 	if (pbuddy_mlmepriv && check_fwstate(pbuddy_mlmepriv, WIFI_ASOC_STATE) == _TRUE &&
-			check_fwstate(pbuddy_mlmepriv, WIFI_STATION_STATE) == _TRUE) {
+			check_fwstate(pbuddy_mlmepriv, WIFI_STATION_STATE) == _TRUE &&
+			check_fwstate(pmlmepriv, WIFI_ASOC_STATE) != _TRUE) {
 		DBG_871X("scan on %s is cancelled, another interface is the client here\n", ndev->name);
 		ret = -EBUSY;
 		goto exit;


### PR DESCRIPTION
[os_dep: fix disallow scan on buddy interface if configured as AP](https://github.com/wirenboard/rtl8723bu/commit/caf229965b4e9bb8828e147df625b179fa8310d9)

Previous version forbids scan on an unconfigured interface if the second one is configured as AP, though this combination does not break anything.

[os_dep: check buddy interface before starting new client or AP](https://github.com/wirenboard/rtl8723bu/commit/d4f59aab26831bf421b0bfdf33aea68b8e9dd001)

This patch forbids configuration of the second interface with the same type of connection as the first one.

Previously user could not bring multiple client connections up using NetworkManager because network scan is forbidden. This measure can't stop from configuring two AP connections and maybe two clients would still be configured without scan.

[os_dep: allow scan with client buddy if this interface is up](https://github.com/wirenboard/rtl8723bu/commit/4728da674a6fe266fa6f1ee584d367bb3600cbe0)

This patch allows scanning on AP interface if its buddy is up as a client. In this configuration client connection does not break.